### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,41 @@ To import, you can just use a relative path like:
 
 Or, even better, you can setup your build environment to have a path to the simplekit folder. For example in Vite:
 
-- << (Vite config setup TBD) explain how to setup paths in vite config and typescript config.>>
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  resolve: {
+    alias: {
+      simplekit: path.resolve(__dirname, './simplekit/src'),
+    },
+  },
+});
+```
+
+And in `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "paths": {
+      "simplekit/*": ["simplekit/src/*"]
+    }
+  }
+}
+```
 
 Git doesn't automatically init and update submodules automatically, so you'll need to do it on command line the first time you clone your main repo.
 
-- << git cloning instructions TBD >>
+```bash
+git clone --recursive https://github.com/your/repo.git
+# or if you forgot --recursive
+git submodule update --init --recursive
+```
+
 
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,6 +8,17 @@ At the lowest level `src/windowing-system` simulates a browser window system. It
 
 `coalesceEvents` is used to merge frequent events such as `mousemove` or `resize` so that only the most recent is processed each frame.
 
+## Run Loop
+
+Every mode in SimpleKit is driven by a simple run loop. The windowing system collects DOM events and queues them until `createWindowingSystem` calls your run loop handler. During each tick the following steps occur:
+
+1. Pending events are translated and dispatched.
+2. Animation callbacks update state based on the current `skTime` value.
+3. In imperative mode, any invalidated layouts are recomputed.
+4. Finally the draw callback renders the user interface to the canvas.
+
+Because the loop is under your control it is easy to integrate SimpleKit with existing rendering or game loops.
+
 ## Event System
 
 The `src/events` module defines the event classes used by the toolkit (`SKEvent`, `SKMouseEvent`, `SKKeyboardEvent`, `SKResizeEvent`). Fundamental events from the windowing system are converted into these high‑level events by **event translators**. The default translators support clicks, double clicks and drag sequences. Additional translators can be registered with `addSKEventTranslator()`.
@@ -46,3 +57,14 @@ Layout strategies live under `src/layout`. The default `FixedLayout` positions c
 ## Utility Helpers
 
 `src/utility` contains small helper functions for geometry calculations (distance, vectors), hit testing and text measurement. These are re‑exported by `simplekit/utility` and can be used directly by applications or custom widgets.
+
+## Extending SimpleKit
+
+The core library is intentionally small so that students can read through the code with ease. New widgets can be built by subclassing `SKElement` and implementing the sizing and drawing hooks. Likewise you can create custom layout strategies by exporting a class that implements the `Layout` interface. For specialised input, register additional event translators with `addSKEventTranslator` or send your own `SKEvent` instances with `sendSKEvent`.
+
+## See Also
+
+- [canvas-mode.md](./canvas-mode.md)
+- [events.md](./events.md)
+- [getting-started.md](./getting-started.md)
+- [README.md](../README.md)

--- a/docs/canvas-mode.md
+++ b/docs/canvas-mode.md
@@ -68,3 +68,17 @@ You may provide your own translators using `addSKEventTranslator(translator)` wh
 4. SimpleKit runs an internal loop that translates events, dispatches them to your listener, then calls your animation and draw callbacks every frame.
 
 Canvas mode does not handle any widgets or layout; you are free to draw whatever you like to the canvas using the provided graphics context.
+
+## Customising the Canvas
+
+`startSimpleKit` automatically inserts a canvas element that fills the browser window. The helper in `common.ts` sets a default background colour of `whitesmoke`. If you want to style the canvas further simply access the element returned by `startSimpleKit` and adjust its CSS properties:
+
+```ts
+const info = startSimpleKit();
+if (info) {
+  const canvas = document.querySelector('canvas')!;
+  canvas.style.border = '1px solid black';
+}
+```
+
+The canvas resizes with the window so your drawing code should rely on `gc.canvas.width` and `gc.canvas.height` each frame.

--- a/docs/events.md
+++ b/docs/events.md
@@ -50,6 +50,21 @@ Four translators are provided:
 Applications can add their own translators using `addSKEventTranslator()` in
 both runtime modes.
 
+### Writing a translator
+
+An event translator is an object with an `update(fundamentalEvent)` method. The method is called for every fundamental event and may return a newly constructed `SKEvent`. Translators run in the order they are registered which makes it possible to chain behaviours or override defaults.
+
+```ts
+const wheelTranslator = {
+  update(fe) {
+    if (fe.type === 'wheel') {
+      return new SKEvent('wheel', fe.timeStamp, fe.deltaY);
+    }
+  }
+};
+addSKEventTranslator(wheelTranslator);
+```
+
 ## Dispatching Events
 
 In **canvas mode** all translated events are delivered to the global event
@@ -80,3 +95,4 @@ Widgets may emit their own high level events. For example `SKButton` emits an
 `action` event when clicked and `SKTextfield` emits `textchanged` whenever its
 text content updates. These events flow through the same dispatch mechanism and
 can be observed using `addEventListener` on the widget instance.
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -84,3 +84,9 @@ The repository includes a small build script powered by [tsup](https://github.co
 - `npm test` – runs the Jest test suite found under `__tests__/`.
 
 You rarely need to build when using `npm link` or the submodule approach, but it is useful when publishing the package or running tests.
+
+## Running the examples
+
+The `examples/` folder contains small demos that showcase different parts of the toolkit. After cloning the repository run `npm start` and open the desired HTML file in your browser. Any changes to the source or the example code will trigger an automatic rebuild.
+
+If you add your own example remember to include the TypeScript files under `examples/` so the build script can compile them.


### PR DESCRIPTION
## Summary
- expand README with submodule and path config details
- document SimpleKit's run loop and extension points
- document canvas customisation
- show how to write an event translator
- mention example projects in getting started guide

## Testing
- `npm test` *(fails: jest not found)*